### PR TITLE
Don't log complete responses

### DIFF
--- a/server/anoixo-server/app.py
+++ b/server/anoixo-server/app.py
@@ -51,7 +51,12 @@ def log_request(response):
     print(f'[{time.asctime()}] {source_address} {request.method} {request.path} {response.status_code}', flush=True)
     print(f'\tTime: {exec_time}', flush=True)
     print(f'\tRequest: {request.json}', flush=True)
-    print(f'\tResponse: {response.json}', flush=True)
+    response_json = response.json
+    if isinstance(response_json, list):
+        response_log = f'<{len(response_json)} results>'
+    else:
+        response_log = response_json
+    print(f'\tResponse: {response_log}', flush=True)
     return response
 
 


### PR DESCRIPTION
Logging large responses slows down the response time considerably, so just log the number of results instead of the complete JSON response.

Part of prep + cleanup for #135 