### PR TITLE
Pagination in frontend

### DIFF
--- a/client/anoixo-client/src/results/Results.tsx
+++ b/client/anoixo-client/src/results/Results.tsx
@@ -118,7 +118,9 @@ const Results: React.FC<Props> = (props: Props) => {
       anchor="right"
       PaperProps={{ classes: { root: 'results-paper' } }}
     >
-      <div className="results-content">{display}</div>
+      <div id="results-content" className="results-content">
+        {display}
+      </div>
     </Drawer>
   );
 };

--- a/client/anoixo-client/src/results/ResultsListing.tsx
+++ b/client/anoixo-client/src/results/ResultsListing.tsx
@@ -41,17 +41,24 @@ const ResultsListing: React.FC<Props> = (props: Props) => {
     const pageEnd = pageStart + PAGE_SIZE;
     const totalPages = Math.ceil(props.results.length / PAGE_SIZE);
     const resultsForPage = props.results.slice(pageStart, pageEnd);
+    const pagination = (
+      <Pagination
+        className="results-item results-pagination"
+        count={totalPages}
+        page={page}
+        onChange={handlePageChange}
+        showFirstButton
+        showLastButton
+      />
+    );
 
     resultsView = (
       <div>
+        {pagination}
         {resultsForPage.map((passage, index) => (
           <PassageCard key={index} passage={passage} passageIndex={index} />
         ))}
-        <Pagination
-          count={totalPages}
-          page={page}
-          onChange={handlePageChange}
-        />
+        {pagination}
       </div>
     );
   } else {

--- a/client/anoixo-client/src/results/ResultsListing.tsx
+++ b/client/anoixo-client/src/results/ResultsListing.tsx
@@ -1,4 +1,4 @@
-import React, { memo } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { SuccessResult } from './ResultTypes';
 import { Query } from '../query/QueryTypes';
 import BackForwardButton from '../common/BackForwardButton';
@@ -6,6 +6,7 @@ import CopyrightNotice from './CopyrightNotice';
 import PassageCard from './PassageCard';
 import VerbalizedQuery from './VerbalizedQuery';
 import Alert from '@material-ui/lab/Alert';
+import Pagination from '@material-ui/lab/Pagination';
 import Typography from '@material-ui/core/Typography';
 import './css/ResultsListing.css';
 
@@ -15,13 +16,44 @@ type Props = {
   closeResults: () => void;
 };
 
-const ResultsListing: React.FC<Props> = memo((props: Props) => {
+const PAGE_SIZE = 10;
+
+const ResultsListing: React.FC<Props> = (props: Props) => {
+  const [page, setPage] = useState(1);
+  const handlePageChange = useCallback(
+    (event: React.ChangeEvent<unknown>, value: number) => {
+      setPage(value);
+    },
+    [setPage]
+  );
+
+  useEffect(() => {
+    // Temporary hack for scrolling to top of page after page changes
+    const resultsDrawer = document.getElementById('results-content');
+    resultsDrawer && resultsDrawer.scrollIntoView(true);
+  }, [page]);
+
   const hasResults = props.results.length > 0;
   let resultsView;
+
   if (hasResults) {
-    resultsView = props.results.map((passage, index) => (
-      <PassageCard key={index} passage={passage} passageIndex={index} />
-    ));
+    const pageStart = (page - 1) * PAGE_SIZE;
+    const pageEnd = pageStart + PAGE_SIZE;
+    const totalPages = Math.ceil(props.results.length / PAGE_SIZE);
+    const resultsForPage = props.results.slice(pageStart, pageEnd);
+
+    resultsView = (
+      <div>
+        {resultsForPage.map((passage, index) => (
+          <PassageCard key={index} passage={passage} passageIndex={index} />
+        ))}
+        <Pagination
+          count={totalPages}
+          page={page}
+          onChange={handlePageChange}
+        />
+      </div>
+    );
   } else {
     resultsView = (
       <Alert className="results-item" severity="info">
@@ -52,6 +84,6 @@ const ResultsListing: React.FC<Props> = memo((props: Props) => {
       />
     </div>
   );
-});
+};
 
 export default ResultsListing;

--- a/client/anoixo-client/src/results/css/ResultsListing.css
+++ b/client/anoixo-client/src/results/css/ResultsListing.css
@@ -8,3 +8,7 @@
 .results-item {
   margin: 1.2rem;
 }
+
+.results-pagination > ul {
+  justify-content: center;
+}

--- a/client/anoixo-client/src/results/tests/ResultsListing.test.tsx
+++ b/client/anoixo-client/src/results/tests/ResultsListing.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import { mount } from 'enzyme';
 import withMarkup from '../../test/helpers/withMarkup';
 import { TextContextProvider } from '../../texts/TextContext';
@@ -9,155 +9,219 @@ import ResultsListing from '../ResultsListing';
 import { SuccessResult } from '../ResultTypes';
 
 describe('ResultsListing component', () => {
-  it('displays a message if no results were passed in', () => {
-    const result: SuccessResult = [];
-    const { getByText } = render(
-      <TextContextProvider text={TextName.NLF}>
-        <ResultsListing
-          query={{ sequences: [] }}
-          results={result}
-          closeResults={() => {}}
-        />
-      </TextContextProvider>
-    );
-    const noResultsFoundMessage = getByText(
-      'No results were found for your search.'
-    );
-    expect(noResultsFoundMessage).toBeInTheDocument();
+  describe('results view', () => {
+    it('displays a message if no results were passed in', () => {
+      const result: SuccessResult = [];
+      const { getByText } = render(
+        <TextContextProvider text={TextName.NLF}>
+          <ResultsListing
+            query={{ sequences: [] }}
+            results={result}
+            closeResults={() => {}}
+          />
+        </TextContextProvider>
+      );
+      const noResultsFoundMessage = getByText(
+        'No results were found for your search.'
+      );
+      expect(noResultsFoundMessage).toBeInTheDocument();
+    });
+
+    it('displays passage cards for results if results were passed in', () => {
+      const result = [
+        { references: [], words: [], translation: '' },
+        { references: [], words: [], translation: '' },
+        { references: [], words: [], translation: '' },
+      ];
+      const wrapper = mount(
+        <TextContextProvider text={TextName.NLF}>
+          <ResultsListing
+            query={{ sequences: [] }}
+            results={result}
+            closeResults={() => {}}
+          />
+        </TextContextProvider>
+      );
+      expect(wrapper.find(PassageCard)).toHaveLength(3);
+    });
+
+    it('does not display the no results found message if there are results', () => {
+      const result = [{ references: [], words: [], translation: '' }];
+      const { queryByText } = render(
+        <TextContextProvider text={TextName.NLF}>
+          <ResultsListing
+            query={{ sequences: [] }}
+            results={result}
+            closeResults={() => {}}
+          />
+        </TextContextProvider>
+      );
+      const noResultsFoundMessage = queryByText(
+        'No results were found for your search.'
+      );
+      expect(noResultsFoundMessage).toBeNull();
+    });
   });
 
-  it('displays passage cards for results if results were passed in', () => {
-    const result = [
-      { references: [], words: [], translation: '' },
-      { references: [], words: [], translation: '' },
-      { references: [], words: [], translation: '' },
-    ];
-    const wrapper = mount(
-      <TextContextProvider text={TextName.NLF}>
-        <ResultsListing
-          query={{ sequences: [] }}
-          results={result}
-          closeResults={() => {}}
-        />
-      </TextContextProvider>
-    );
-    expect(wrapper.find(PassageCard)).toHaveLength(3);
-  });
-
-  it('does not display the no results found message if there are results', () => {
-    const result = [{ references: [], words: [], translation: '' }];
-    const { queryByText } = render(
-      <TextContextProvider text={TextName.NLF}>
-        <ResultsListing
-          query={{ sequences: [] }}
-          results={result}
-          closeResults={() => {}}
-        />
-      </TextContextProvider>
-    );
-    const noResultsFoundMessage = queryByText(
-      'No results were found for your search.'
-    );
-    expect(noResultsFoundMessage).toBeNull();
-  });
-
-  it('displays a verbalization of the query when there were results', () => {
-    const query = {
-      sequences: [
-        [
-          {
-            attributes: {
-              case: 'genitive',
+  describe('verbalization', () => {
+    it('displays a verbalization of the query when there were results', () => {
+      const query = {
+        sequences: [
+          [
+            {
+              attributes: {
+                case: 'genitive',
+              },
             },
-          },
+          ],
         ],
-      ],
-    };
-    const result = [{ references: [], words: [], translation: '' }];
-    const { getByText } = render(
-      <TextContextProvider text={TextName.NLF}>
-        <ResultsListing
-          query={query}
-          results={result}
-          closeResults={() => {}}
-        />
-      </TextContextProvider>
-    );
-    expect(withMarkup(getByText)('for a genitive')).toBeInTheDocument();
-  });
+      };
+      const result = [{ references: [], words: [], translation: '' }];
+      const { getByText } = render(
+        <TextContextProvider text={TextName.NLF}>
+          <ResultsListing
+            query={query}
+            results={result}
+            closeResults={() => {}}
+          />
+        </TextContextProvider>
+      );
+      expect(withMarkup(getByText)('for a genitive')).toBeInTheDocument();
+    });
 
-  it('displays a verbalization of the query when there were no results', () => {
-    const query = {
-      sequences: [
-        [
-          {
-            attributes: {
-              case: 'genitive',
+    it('displays a verbalization of the query when there were no results', () => {
+      const query = {
+        sequences: [
+          [
+            {
+              attributes: {
+                case: 'genitive',
+              },
             },
-          },
+          ],
         ],
-      ],
-    };
-    const result: SuccessResult = [];
-    const { getByText } = render(
-      <TextContextProvider text={TextName.NLF}>
-        <ResultsListing
-          query={query}
-          results={result}
-          closeResults={() => {}}
-        />
-      </TextContextProvider>
-    );
-    expect(withMarkup(getByText)('for a genitive')).toBeInTheDocument();
+      };
+      const result: SuccessResult = [];
+      const { getByText } = render(
+        <TextContextProvider text={TextName.NLF}>
+          <ResultsListing
+            query={query}
+            results={result}
+            closeResults={() => {}}
+          />
+        </TextContextProvider>
+      );
+      expect(withMarkup(getByText)('for a genitive')).toBeInTheDocument();
+    });
   });
 
-  it('renders the required copyright notice', () => {
-    const result = [{ references: [], words: [], translation: '' }];
-    const { getByText } = render(
-      <TextContextProvider text={TextName.NLF}>
-        <ResultsListing
-          query={{ sequences: [] }}
-          results={result}
-          closeResults={() => {}}
-        />
-      </TextContextProvider>
-    );
-    const getByTextWithMarkup = withMarkup(getByText);
-    const copyright =
-      'Scripture quotations are from the ESV® Bible (The Holy Bible, English Standard Version®), ' +
-      'copyright © 2001 by Crossway, a publishing ministry of Good News Publishers. Used by permission. All rights ' +
-      'reserved. You may not copy or download more than 500 consecutive verses of the ESV Bible or more than one ' +
-      'half of any book of the ESV Bible.';
-    expect(getByTextWithMarkup(copyright)).toBeInTheDocument();
+  describe('copyright notice', () => {
+    it('renders the required copyright notice', () => {
+      const result = [{ references: [], words: [], translation: '' }];
+      const { getByText } = render(
+        <TextContextProvider text={TextName.NLF}>
+          <ResultsListing
+            query={{ sequences: [] }}
+            results={result}
+            closeResults={() => {}}
+          />
+        </TextContextProvider>
+      );
+      const getByTextWithMarkup = withMarkup(getByText);
+      const copyright =
+        'Scripture quotations are from the ESV® Bible (The Holy Bible, English Standard Version®), ' +
+        'copyright © 2001 by Crossway, a publishing ministry of Good News Publishers. Used by permission. All rights ' +
+        'reserved. You may not copy or download more than 500 consecutive verses of the ESV Bible or more than one ' +
+        'half of any book of the ESV Bible.';
+      expect(getByTextWithMarkup(copyright)).toBeInTheDocument();
+    });
+
+    it('renders the required link to ESV.org', () => {
+      const result = [{ references: [], words: [], translation: '' }];
+      const { getByText } = render(
+        <TextContextProvider text={TextName.NLF}>
+          <ResultsListing
+            query={{ sequences: [] }}
+            results={result}
+            closeResults={() => {}}
+          />
+        </TextContextProvider>
+      );
+      const link = getByText('ESV® Bible');
+      expect(link.getAttribute('href')).toBe('http://www.esv.org/');
+    });
+
+    it('does not render the copyright notice and link if there are no results', () => {
+      const result: SuccessResult = [];
+      const { queryByText } = render(
+        <TextContextProvider text={TextName.NLF}>
+          <ResultsListing
+            query={{ sequences: [] }}
+            results={result}
+            closeResults={() => {}}
+          />
+        </TextContextProvider>
+      );
+      const copyright = queryByText('ESV® Bible');
+      expect(copyright).toBeNull();
+    });
   });
 
-  it('renders the required link to ESV.org', () => {
-    const result = [{ references: [], words: [], translation: '' }];
-    const { getByText } = render(
-      <TextContextProvider text={TextName.NLF}>
-        <ResultsListing
-          query={{ sequences: [] }}
-          results={result}
-          closeResults={() => {}}
-        />
-      </TextContextProvider>
-    );
-    const link = getByText('ESV® Bible');
-    expect(link.getAttribute('href')).toBe('http://www.esv.org/');
-  });
+  describe('pagination', () => {
+    it('displays the correct pages in the pagination if there are results', () => {
+      const result: SuccessResult = [];
+      for (let i = 0; i < 23; i++) {
+        result.push({ references: [], words: [], translation: '' });
+      }
+      const { getAllByLabelText, queryAllByLabelText } = render(
+        <TextContextProvider text={TextName.NLF}>
+          <ResultsListing
+            query={{ sequences: [] }}
+            results={result}
+            closeResults={() => {}}
+          />
+        </TextContextProvider>
+      );
+      expect(getAllByLabelText('page 1').length).toBe(2);
+      expect(getAllByLabelText('Go to page 2').length).toBe(2);
+      expect(getAllByLabelText('Go to page 3').length).toBe(2);
+      expect(queryAllByLabelText('Go to page 4').length).toBe(0);
+    });
 
-  it('does not render the copyright notice and link if there are no results', () => {
-    const result: SuccessResult = [];
-    const { queryByText } = render(
-      <TextContextProvider text={TextName.NLF}>
-        <ResultsListing
-          query={{ sequences: [] }}
-          results={result}
-          closeResults={() => {}}
-        />
-      </TextContextProvider>
-    );
-    const copyright = queryByText('ESV® Bible');
-    expect(copyright).toBeNull();
+    it('goes to the right page when the pagination is clicked', () => {
+      const result: SuccessResult = [];
+      for (let i = 0; i < 23; i++) {
+        result.push({ references: [], words: [], translation: `passage ${i}` });
+      }
+      const { getAllByLabelText, getByText, queryByText } = render(
+        <TextContextProvider text={TextName.NLF}>
+          <ResultsListing
+            query={{ sequences: [] }}
+            results={result}
+            closeResults={() => {}}
+          />
+        </TextContextProvider>
+      );
+      const page2Button = getAllByLabelText('Go to page 2')[0];
+      fireEvent.click(page2Button);
+      expect(queryByText('passage 9')).toBeNull();
+      expect(getByText('passage 10')).toBeInTheDocument();
+      expect(getByText('passage 19')).toBeInTheDocument();
+      expect(queryByText('passage 20')).toBeNull();
+    });
+
+    it('does not display pagination if there are no results', () => {
+      const result: SuccessResult = [];
+      const { queryAllByLabelText } = render(
+        <TextContextProvider text={TextName.NLF}>
+          <ResultsListing
+            query={{ sequences: [] }}
+            results={result}
+            closeResults={() => {}}
+          />
+        </TextContextProvider>
+      );
+      expect(queryAllByLabelText('page 1').length).toBe(0);
+    });
   });
 });


### PR DESCRIPTION
Quick temporary fix for #90. Removes slowdown from rendering lots of results, but doesn't address the slowdown (or the other quota/performance costs) from requesting all those results in the first place.